### PR TITLE
fix(dashboard): repara la resolucion rota del merge del PR #53

### DIFF
--- a/src/app/pages/Dashboard.tsx
+++ b/src/app/pages/Dashboard.tsx
@@ -9,10 +9,13 @@ import { CommandBar } from '../components/CommandBar';
 import {
   useApiBoards, useApiBoardColumns, useApiProjectMembers, useApiProjects, useApiTasks,
   useApiTaskAssignments, useApiTaskWarnings, useApiGithubPushes,
+  useApiGamificationProfile, useApiUserBadges,
 } from '../hooks/useProjectData';
 import { LevelProgress } from '../components/Gamification';
 import { useAuth } from '../context/AuthContext';
-import { shouldShowInGenericProjectDisplays, compareProjectsForGenericPriority } from '../utils/projectStatus';
+import {
+  compareProjectsForGenericPriority, shouldShowInGenericProjectDisplays,
+} from '../utils/projectStatus';
 import { formatProjectDate } from '../utils/projectDates';
 import { computeProjectProgress, getProjectHealth, type ProjectHealth } from '../utils/projectHealth';
 import {
@@ -44,18 +47,13 @@ const HEALTH_LABEL: Record<ProjectHealth, string> = {
 };
 
 const PANEL_PAGE_SIZE = 8;
-const DAY_MS = 24 * 60 * 60 * 1000;
-
-function startOfDay(d: Date): Date {
-  const copy = new Date(d);
-  copy.setHours(0, 0, 0, 0);
-  return copy;
-}
 
 function relativeDueLabel(dueIso: string, now: Date): { label: string; tone: 'overdue' | 'today' | 'tomorrow' | 'soon' } {
-  const due = startOfDay(new Date(dueIso));
-  const today = startOfDay(now);
-  const diff = Math.round((due.getTime() - today.getTime()) / DAY_MS);
+  const due = new Date(dueIso);
+  due.setHours(0, 0, 0, 0);
+  const today = new Date(now);
+  today.setHours(0, 0, 0, 0);
+  const diff = Math.round((due.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
   if (diff < 0) {
     const abs = Math.abs(diff);
     return { label: abs === 1 ? 'vencida ayer' : `vencida hace ${abs}d`, tone: 'overdue' };
@@ -68,10 +66,10 @@ function relativeDueLabel(dueIso: string, now: Date): { label: string; tone: 'ov
 function taskStatusColor(name: string) {
   const n = name.trim().toLowerCase();
   if (n.includes('backlog')) return '#64748b';
-  if (n.includes('to do') || n.includes('por hacer') || n.includes('todo')) return '#0ea5e9';
-  if (n.includes('progress') || n.includes('progreso') || n.includes('curso')) return '#f59e0b';
+  if (n.includes('to do') || n.includes('por hacer')) return '#0ea5e9';
+  if (n.includes('progress') || n.includes('progreso')) return '#f59e0b';
   if (n.includes('review') || n.includes('revisión') || n.includes('revision')) return '#8b5cf6';
-  if (n.includes('done') || n.includes('completad') || n.includes('finalizad') || n.includes('hecho')) return '#22c55e';
+  if (n.includes('done') || n.includes('completad') || n.includes('finalizad')) return '#22c55e';
   if (n.includes('block') || n.includes('bloque')) return '#ef4444';
   return '#14b8a6';
 }
@@ -119,10 +117,8 @@ export default function Dashboard() {
   const navigate = useNavigate();
   const { user } = useAuth();
   const currentUserId = useMemo(() => Number(user?.id ?? 0), [user?.id]);
-  const validUserId = !Number.isNaN(currentUserId) && currentUserId > 0 ? currentUserId : null;
-
   const { data: projects, loading: loadingProjects, error: errorProjects, refetch: refetchProjects } = useApiProjects();
-  const { data: tasks, loading: loadingTasks, refetch: refetchTasks } = useApiTasks();
+  const { data: tasks, loading: loadingTasks, statuses, refetch: refetchTasks } = useApiTasks();
   const { data: boards, loading: loadingBoards } = useApiBoards();
   const { data: boardColumns } = useApiBoardColumns();
   const { data: myProjectMemberships, loading: loadingMemberships } = useApiProjectMembers(
@@ -135,17 +131,16 @@ export default function Dashboard() {
   const { data: pushes } = useApiGithubPushes();
   const { data: gamificationProfile } = useApiGamificationProfile();
   const { data: userBadges } = useApiUserBadges();
-
   const isStakeholderUser = user?.role === 'stakeholder';
   const isAdminUser = user?.role === 'admin';
-  // Admins & project managers see the whole team; everyone else sees only their own tasks.
-  const isManagerView = user?.role === 'admin' || user?.role === 'project_manager';
 
   const loading = loadingProjects || loadingTasks || loadingBoards || (isAdminUser ? false : loadingMemberships);
 
   const visibleProjectIds = useMemo(() => {
     if (isAdminUser) return new Set<number>((projects ?? []).map((p) => p.id_project));
-    return new Set<number>((myProjectMemberships ?? []).map((m) => m.project));
+    const ids = new Set<number>();
+    (myProjectMemberships ?? []).forEach((m) => ids.add(m.project));
+    return ids;
   }, [isAdminUser, projects, myProjectMemberships]);
 
   const visibleProjects = useMemo(
@@ -165,124 +160,101 @@ export default function Dashboard() {
     return m;
   }, [boards]);
 
-  const columnNameById = useMemo(() => {
-    const m = new Map<number, string>();
-    (columns ?? []).forEach((c) => m.set(c.id_column, c.name));
-    return m;
-  }, [columns]);
-
-  // Set of task ids assigned to the current user (assignments table + legacy field).
-  const myTaskIdSet = useMemo(() => {
-    const ids = new Set<number>();
-    if (validUserId == null) return ids;
-    (taskAssignments ?? []).forEach((a) => { if (a.assigned_to === validUserId) ids.add(a.task); });
-    (tasks ?? []).forEach((t) => { if (t.assigned_to === validUserId) ids.add(t.id_task); });
-    return ids;
-  }, [taskAssignments, tasks, validUserId]);
-
-  // Tasks within the user's visible projects.
   const scopedTasks = useMemo(() => {
+    const list = tasks ?? [];
     if (visibleProjectIds.size === 0) return [];
-    return (tasks ?? []).filter((t) => {
+    return list.filter((t) => {
       if (t.project != null && visibleProjectIds.has(t.project)) return true;
       const pid = boardProjectMap.get(t.board ?? 0);
       return pid != null && visibleProjectIds.has(pid);
     });
   }, [tasks, boardProjectMap, visibleProjectIds]);
 
-  // What the dashboard is "about": everything for managers, only my tasks for regular users.
-  const dashboardTasks = useMemo(
-    () => (isManagerView ? scopedTasks : scopedTasks.filter((t) => myTaskIdSet.has(t.id_task))),
-    [isManagerView, scopedTasks, myTaskIdSet],
+  const scopedTaskIdSet = useMemo(() => new Set(scopedTasks.map((t) => t.id_task)), [scopedTasks]);
+  const scopedWarnings = useMemo(
+    () => (warnings ?? []).filter((w) => scopedTaskIdSet.has(w.task)),
+    [warnings, scopedTaskIdSet],
   );
 
-  const dashboardTaskIdSet = useMemo(() => new Set(dashboardTasks.map((t) => t.id_task)), [dashboardTasks]);
-  const scopedWarnings = useMemo(
-    () => (warnings ?? []).filter((w) => dashboardTaskIdSet.has(w.task)),
-    [warnings, dashboardTaskIdSet],
-  );
+  const taskStatusNameById = useMemo(() => {
+    const m = new Map<number, string>();
+    statuses.forEach((s) => m.set(s.id_status, s.name));
+    return m;
+  }, [statuses]);
 
   const refetchAll = () => { refetchProjects(); refetchTasks(); };
 
-  // ── KPIs (task-focused) ──
+  // ── KPIs ──
   const kpis = useMemo(() => {
-    const tList = dashboardTasks;
+    const pList = visibleProjects.filter((p) => shouldShowInGenericProjectDisplays(p.status));
+    const tList = scopedTasks;
     const now = new Date();
+    const totalProjects = pList.length;
     const totalTasks = tList.length;
     const completed = tList.filter((t) => t.completed_at != null).length;
     const overdue = tList.filter((t) => !t.completed_at && t.due_date && new Date(t.due_date) < now).length;
     const open = totalTasks - completed;
-    const projectCount = isManagerView
-      ? visibleProjects.filter((p) => shouldShowInGenericProjectDisplays(p.status)).length
-      : new Set(dashboardTasks.map((t) => t.project)).size;
-    return { totalTasks, completed, open, overdue, projectCount };
-  }, [dashboardTasks, visibleProjects, isManagerView]);
+    return { totalProjects, totalTasks, completed, open, overdue };
+  }, [visibleProjects, scopedTasks]);
   const activeWarningsCount = scopedWarnings.length;
 
-  // ── Task status distribution (donut) ──
-  const taskStatusData = useMemo(() => {
-    const counts = new Map<string, number>();
-    dashboardTasks.forEach((t) => {
-      const name = columnNameById.get(t.board_column) ?? 'Sin estado';
-      counts.set(name, (counts.get(name) ?? 0) + 1);
-    });
-    return [...counts.entries()]
-      .map(([name, value]) => ({ name, value, color: taskStatusColor(name) }))
-      .sort((a, b) => b.value - a.value);
-  }, [dashboardTasks, columnNameById]);
-  const taskStatusTotal = useMemo(() => taskStatusData.reduce((s, d) => s + d.value, 0), [taskStatusData]);
-
-  // ── Burndown ──
-  const sprintOptions = useMemo(() => {
-    const list = (sprints ?? []).filter((s) => visibleProjectIds.has(s.project));
-    const rank = (s: ApiSprint) => (s.status === 'active' ? 0 : s.status === 'planned' ? 1 : 2);
-    return [...list].sort((a, b) => {
-      if (rank(a) !== rank(b)) return rank(a) - rank(b);
-      return (b.start_date ?? '').localeCompare(a.start_date ?? '');
-    });
-  }, [sprints, visibleProjectIds]);
-
-  const [selectedSprintId, setSelectedSprintId] = useState<number | null>(null);
-  const activeSprintId = selectedSprintId ?? sprintOptions[0]?.id_sprint ?? null;
-  const activeSprint = useMemo(
-    () => sprintOptions.find((s) => s.id_sprint === activeSprintId) ?? null,
-    [sprintOptions, activeSprintId],
-  );
-  const burndownData = useMemo(() => {
-    if (!activeSprint) return [];
-    const sprintTasks = dashboardTasks.filter((t) => t.sprint === activeSprint.id_sprint);
-    return buildBurndownSeries(activeSprint, sprintTasks, new Date());
-  }, [activeSprint, dashboardTasks]);
-
-  // ── My tasks panel (always personal, pending only) ──
+  // ── My tasks ──
   const myTasks = useMemo(() => {
-    if (validUserId == null) return [];
+    if (!user) return [];
+    const uid = Number(user.id);
+    const assignmentMap = new Map<number, Set<number>>();
+    (taskAssignments ?? []).forEach((a) => {
+      const s = assignmentMap.get(a.task) ?? new Set<number>();
+      s.add(a.assigned_to);
+      assignmentMap.set(a.task, s);
+    });
     return scopedTasks
-      .filter((t) => !t.completed_at && myTaskIdSet.has(t.id_task))
+      .filter((t) => {
+        if (t.completed_at) return false;
+        const assigned = assignmentMap.get(t.id_task);
+        if (assigned && assigned.size > 0) return assigned.has(uid);
+        return t.assigned_to === uid;
+      })
       .sort((a, b) => {
         const ad = a.due_date ? new Date(a.due_date).getTime() : Number.POSITIVE_INFINITY;
         const bd = b.due_date ? new Date(b.due_date).getTime() : Number.POSITIVE_INFINITY;
         return ad - bd;
       });
-  }, [scopedTasks, myTaskIdSet, validUserId]);
+  }, [scopedTasks, taskAssignments, user]);
 
   const [myTasksPage, setMyTasksPage] = useState(0);
   const [pushesPage, setPushesPage] = useState(0);
 
-  const paginatedMyTasks = useMemo(() => myTasks.slice(myTasksPage * PANEL_PAGE_SIZE, myTasksPage * PANEL_PAGE_SIZE + PANEL_PAGE_SIZE), [myTasks, myTasksPage]);
-  const paginatedPushes = useMemo(() => (pushes ?? []).slice(pushesPage * PANEL_PAGE_SIZE, pushesPage * PANEL_PAGE_SIZE + PANEL_PAGE_SIZE), [pushes, pushesPage]);
+  const paginatedMyTasks = useMemo(() => {
+    const start = myTasksPage * PANEL_PAGE_SIZE;
+    return myTasks.slice(start, start + PANEL_PAGE_SIZE);
+  }, [myTasks, myTasksPage]);
+
+  const paginatedPushes = useMemo(() => {
+    const start = pushesPage * PANEL_PAGE_SIZE;
+    return (pushes ?? []).slice(start, start + PANEL_PAGE_SIZE);
+  }, [pushes, pushesPage]);
+
   const myTasksTotalPages = Math.max(1, Math.ceil(myTasks.length / PANEL_PAGE_SIZE));
   const pushesTotalPages = Math.max(1, Math.ceil((pushes ?? []).length / PANEL_PAGE_SIZE));
 
-  // ── Upcoming tasks (next 7 days + recent overdue) ──
+  // ── Upcoming tasks (due in next 7 days, plus recent overdue) ──
   const upcomingDueTasks = useMemo(() => {
-    const today = startOfDay(new Date());
+    const now = new Date();
+    const today = new Date(now);
+    today.setHours(0, 0, 0, 0);
     const cutoff = new Date(today);
     cutoff.setDate(cutoff.getDate() + 8);
-    return dashboardTasks
-      .filter((t) => !t.completed_at && t.due_date && new Date(t.due_date).getTime() < cutoff.getTime())
+    const out = scopedTasks
+      .filter((t) => {
+        if (t.completed_at) return false;
+        if (!t.due_date) return false;
+        const d = new Date(t.due_date);
+        return d.getTime() < cutoff.getTime();
+      })
       .sort((a, b) => new Date(a.due_date!).getTime() - new Date(b.due_date!).getTime());
-  }, [dashboardTasks]);
+    return out;
+  }, [scopedTasks]);
 
   // ── Task-focused analytics (dashboard headline) ──
   const statusNameById = useMemo(() => buildStatusNameMap(statuses), [statuses]);
@@ -301,18 +273,25 @@ export default function Dashboard() {
   const upcomingProjects = useMemo(() => {
     return [...visibleProjects]
       .filter((p) => shouldShowInGenericProjectDisplays(p.status))
-      .filter((p) => relevantIds == null || relevantIds.has(p.id_project))
-      .sort(compareProjectsForGenericPriority)
-      .map((p) => {
-        const progress = computeProjectProgress(p.id_project, taskList, boardList);
-        const now = new Date();
-        const overdue = taskList.filter((t) => {
-          const belongs = t.project === p.id_project || boardProjectMap.get(t.board ?? 0) === p.id_project;
-          return belongs && !t.completed_at && t.due_date && new Date(t.due_date) < now;
-        }).length;
-        return { project: p, progress, overdue };
-      });
-  }, [visibleProjects, tasks, boards, boardProjectMap, isManagerView, dashboardTasks]);
+      .sort(compareProjectsForGenericPriority);
+  }, [visibleProjects]);
+
+  const projectCards = useMemo(() => {
+    const taskList = tasks ?? [];
+    const boardList = boards ?? [];
+    return upcomingProjects.map((p) => {
+      const progress = computeProjectProgress(p.id_project, taskList, boardList);
+      const health = getProjectHealth(p, progress);
+      const now = new Date();
+      const overdue = taskList.filter((t) => {
+        const belongs = t.project === p.id_project
+          || boardProjectMap.get(t.board ?? 0) === p.id_project;
+        if (!belongs) return false;
+        return !t.completed_at && t.due_date && new Date(t.due_date) < now;
+      }).length;
+      return { project: p, progress, health, overdue };
+    });
+  }, [upcomingProjects, tasks, boards, boardProjectMap]);
 
   const isAuthExpiredError = useMemo(() => {
     if (!errorProjects) return false;
@@ -328,7 +307,10 @@ export default function Dashboard() {
           {isAuthExpiredError ? 'Tu sesión venció. Vuelve a iniciar sesión.' : errorProjects}
         </p>
         <button
-          onClick={() => { if (isAuthExpiredError) { window.location.href = '/'; return; } refetchAll(); }}
+          onClick={() => {
+            if (isAuthExpiredError) { window.location.href = '/'; return; }
+            refetchAll();
+          }}
           className="mt-3 text-[12px] text-primary hover:underline"
         >
           {isAuthExpiredError ? 'Ir al inicio' : 'Reintentar'}
@@ -453,31 +435,21 @@ export default function Dashboard() {
           </ChartCard>
         </motion.div>
 
-        {/* Burndown */}
+        {/* Próximas a Vencer */}
         <motion.div
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.25, delay: 0.15, ease: 'easeOut' }}
           className="bg-card border border-border rounded-[8px] flex flex-col"
         >
-          <div className="flex items-center justify-between gap-2 mb-3">
-            <div className="flex items-center gap-2 min-w-0">
-              <TrendingDown className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
-              <h2 className="text-[13px] font-semibold text-foreground">Burndown</h2>
+          <div className="flex items-center justify-between px-4 py-2.5 border-b border-border">
+            <div className="flex items-center gap-2">
+              <Calendar className="w-3.5 h-3.5 text-muted-foreground" />
+              <h2 className="text-[13px] font-semibold text-foreground">Próximas a Vencer</h2>
             </div>
-            {sprintOptions.length > 0 && (
-              <select
-                value={activeSprintId ?? ''}
-                onChange={(e) => setSelectedSprintId(e.target.value ? Number(e.target.value) : null)}
-                className="h-7 max-w-[200px] rounded-sm border border-border bg-surface-secondary px-2 text-[11px] text-foreground"
-              >
-                {sprintOptions.map((s) => (
-                  <option key={s.id_sprint} value={s.id_sprint}>
-                    {s.name}{projectById.get(s.project) ? ` · ${projectById.get(s.project)}` : ''}
-                  </option>
-                ))}
-              </select>
-            )}
+            <span className="text-[10px] text-muted-foreground">
+              {upcomingDueTasks.length} en 7 días
+            </span>
           </div>
           {upcomingDueTasks.length === 0 ? (
             <div className="flex-1 flex items-center justify-center py-8">
@@ -542,7 +514,7 @@ export default function Dashboard() {
         </motion.div>
       </div>
 
-      {/* ───────── Próximas a Vencer ───────── */}
+      {/* ───────── Project cards ───────── */}
       <motion.div
         initial={{ opacity: 0, y: 8 }}
         animate={{ opacity: 1, y: 0 }}
@@ -551,7 +523,9 @@ export default function Dashboard() {
       >
         <div className="flex items-center justify-between mb-3">
           <h2 className="text-[13px] font-semibold text-foreground">Mis Proyectos</h2>
-          <Link to="/projects" className="text-[11px] text-primary hover:underline font-medium inline-flex items-center gap-1">Ver todos <ArrowRight className="w-3 h-3" /></Link>
+          <Link to="/projects" className="text-[11px] text-primary hover:underline font-medium inline-flex items-center gap-1">
+            Ver todos <ArrowRight className="w-3 h-3" />
+          </Link>
         </div>
         {loading ? (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
@@ -560,22 +534,35 @@ export default function Dashboard() {
             ))}
           </div>
         ) : projectCards.length === 0 ? (
-          <div className="py-10 text-center text-[12px] text-muted-foreground">No tienes proyectos asignados.</div>
+          <div className="py-10 text-center text-[12px] text-muted-foreground">
+            No tienes proyectos asignados.
+          </div>
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-            {projectCards.slice(0, 6).map(({ project, progress, overdue }) => (
+            {projectCards.slice(0, 6).map(({ project, progress, health, overdue }) => (
               <button
                 key={project.id_project}
                 type="button"
                 onClick={() => navigate(`/projects/${project.id_project}`)}
                 className={`bg-card border border-border border-l-[3px] ${HEALTH_BORDER[health]} rounded-[6px] p-3.5 hover:bg-accent/20 hover:border-primary/40 transition-colors text-left`}
               >
-                <h3 className="text-[13px] font-semibold text-foreground truncate mb-2">{project.name}</h3>
+                <div className="flex items-start justify-between gap-2 mb-2">
+                  <h3 className="text-[13px] font-semibold text-foreground truncate flex-1">{project.name}</h3>
+                  <span
+                    className={`w-2 h-2 rounded-full shrink-0 mt-1.5 ${HEALTH_DOT[health]}`}
+                    title={HEALTH_LABEL[health]}
+                  />
+                </div>
                 <div className="flex items-center gap-2 mb-1.5">
                   <div className="flex-1 h-1.5 bg-secondary rounded-full overflow-hidden">
-                    <div className="h-full bg-primary transition-all" style={{ width: `${progress.percentage}%` }} />
+                    <div
+                      className={`h-full transition-all ${HEALTH_BAR[health]}`}
+                      style={{ width: `${progress.percentage}%` }}
+                    />
                   </div>
-                  <span className="text-[11px] font-semibold text-foreground tabular-nums">{progress.percentage}%</span>
+                  <span className="text-[11px] font-semibold text-foreground tabular-nums">
+                    {progress.percentage}%
+                  </span>
                 </div>
                 <div className="flex items-center justify-between text-[10px] text-muted-foreground">
                   <span>{progress.completed} de {progress.total} tareas</span>
@@ -595,8 +582,9 @@ export default function Dashboard() {
       </motion.div>
 
       {/* ───────── Bottom: My Tasks + Git Activity ───────── */}
-      <div className="grid xl:grid-cols-2 gap-3 items-start">
-        {!isStakeholderUser && (
+      {!isStakeholderUser && (
+        <div className="grid xl:grid-cols-2 gap-3 items-start">
+          {/* My tasks */}
           <motion.div
             initial={{ opacity: 0, y: 8 }}
             animate={{ opacity: 1, y: 0 }}
@@ -607,12 +595,20 @@ export default function Dashboard() {
               <div className="flex items-center gap-2">
                 <Calendar className="w-3.5 h-3.5 text-muted-foreground" />
                 <h2 className="text-[13px] font-semibold text-foreground">Mis Tareas Pendientes</h2>
-                {myTasks.length > 0 && <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-primary/10 text-primary">{myTasks.length}</span>}
+                {myTasks.length > 0 && (
+                  <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-primary/10 text-primary">
+                    {myTasks.length}
+                  </span>
+                )}
               </div>
-              <Link to="/backlog" className="text-[11px] text-primary hover:underline font-medium inline-flex items-center gap-1">Ver Backlog <ArrowRight className="w-3 h-3" /></Link>
+              <Link to="/backlog" className="text-[11px] text-primary hover:underline font-medium inline-flex items-center gap-1">
+                Ver Backlog <ArrowRight className="w-3 h-3" />
+              </Link>
             </div>
             {loadingTasks ? (
-              <div className="p-4 space-y-2">{[1, 2, 3].map((i) => <div key={i} className="h-6 animate-pulse bg-secondary rounded" />)}</div>
+              <div className="p-4 space-y-2">
+                {[1, 2, 3].map((i) => <div key={i} className="h-6 animate-pulse bg-secondary rounded" />)}
+              </div>
             ) : myTasks.length === 0 ? (
               <div className="py-8 text-center text-[12px] text-muted-foreground">Sin tareas pendientes.</div>
             ) : (
@@ -633,7 +629,7 @@ export default function Dashboard() {
                       <button
                         key={task.id_task}
                         type="button"
-                        onClick={() => projectId && navigate(`/projects/${projectId}?tab=${task.sprint == null ? 'backlog' : 'sprints'}&task=${task.id_task}`)}
+                        onClick={() => projectId && navigate(`/projects/${projectId}?tab=tareas&task=${task.id_task}`)}
                         className="w-full px-4 py-2.5 hover:bg-accent/30 transition-colors flex items-center gap-3 text-left"
                       >
                         <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: statusCol }} />
@@ -641,7 +637,12 @@ export default function Dashboard() {
                           <div className="text-[12px] font-medium text-foreground truncate">{task.title}</div>
                           <div className="flex items-center gap-2 mt-0.5 min-w-0">
                             <span className="text-[10px] text-muted-foreground truncate">{projectName}</span>
-                            <span className="text-[9px] font-medium px-1.5 py-0.5 rounded-full shrink-0" style={{ backgroundColor: `${statusCol}1a`, color: statusCol }}>{statusLabel}</span>
+                            <span
+                              className="text-[9px] font-medium px-1.5 py-0.5 rounded-full shrink-0"
+                              style={{ backgroundColor: `${statusCol}1a`, color: statusCol }}
+                            >
+                              {statusLabel}
+                            </span>
                           </div>
                         </div>
                         {task.due_date && (
@@ -655,7 +656,9 @@ export default function Dashboard() {
                 </div>
                 {myTasksTotalPages > 1 && (
                   <div className="flex items-center justify-between px-4 py-1.5 border-t border-border">
-                    <span className="text-[10px] text-muted-foreground">Página {myTasksPage + 1} de {myTasksTotalPages}</span>
+                    <span className="text-[10px] text-muted-foreground">
+                      Página {myTasksPage + 1} de {myTasksTotalPages}
+                    </span>
                     <div className="flex items-center gap-1">
                       <button
                         type="button"
@@ -675,7 +678,6 @@ export default function Dashboard() {
               </>
             )}
           </motion.div>
-        )}
 
           {/* Git Activity */}
           <motion.div
@@ -713,7 +715,6 @@ export default function Dashboard() {
                             {commitCount} commit{commitCount !== 1 ? 's' : ''} · {new Date(push.received_at).toLocaleDateString('es-MX', { day: '2-digit', month: 'short', hour: '2-digit', minute: '2-digit' })}
                           </p>
                         </div>
-                        <p className="text-[10px] text-muted-foreground mt-0.5">{commitCount} commit{commitCount !== 1 ? 's' : ''} · {new Date(push.received_at).toLocaleDateString('es-MX', { day: '2-digit', month: 'short', hour: '2-digit', minute: '2-digit' })}</p>
                       </div>
                     );
                   })}
@@ -737,22 +738,13 @@ export default function Dashboard() {
                         className="h-6 px-2 border border-border rounded-[3px] text-[10px] hover:bg-accent disabled:opacity-50"
                       >Sig. ›</button>
                     </div>
-                  );
-                })}
-              </div>
-              {pushesTotalPages > 1 && (
-                <div className="flex items-center justify-between px-4 py-1.5 border-t border-border">
-                  <span className="text-[10px] text-muted-foreground">Página {pushesPage + 1} de {pushesTotalPages}</span>
-                  <div className="flex items-center gap-1">
-                    <button type="button" onClick={() => setPushesPage((p) => Math.max(0, p - 1))} disabled={pushesPage === 0} className="h-6 px-2 border border-border rounded-sm text-[10px] hover:bg-accent disabled:opacity-50">‹ Ant.</button>
-                    <button type="button" onClick={() => setPushesPage((p) => Math.min(pushesTotalPages - 1, p + 1))} disabled={pushesPage >= pushesTotalPages - 1} className="h-6 px-2 border border-border rounded-sm text-[10px] hover:bg-accent disabled:opacity-50">Sig. ›</button>
                   </div>
-                </div>
-              )}
-            </>
-          )}
-        </motion.div>
-      </div>
+                )}
+              </>
+            )}
+          </motion.div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
El merge a1edb45 (Merge main into feature/scrum-poker) dejo Dashboard.tsx sin compilar. Mezclo los dos sistemas de analitica de ambas ramas y dejo:
- variables usadas sin declarar: statuses, columns, health, gamificationProfile
- imports faltantes: useApiGamificationProfile, useApiUserBadges, buildBurndownSeries
- columnNameById declarado dos veces
- un bloque de paginacion de pushes duplicado con llaves mal cerradas (error de sintaxis TS1381 / TS1005 que rompia tsc y, por tanto, el build)

Se restaura el Dashboard de main (2a94c91, ya rediseñado) y se injerta unicamente lo que aportaba el PR #53: la franja de gamificacion (LevelProgress + conteo de insignias) y sus hooks. Se descartan las regresiones que el merge reintrodujo de la version vieja del dashboard.

Verificado: `tsc --noEmit` sin errores y `npm run build` exitoso.